### PR TITLE
update branch references to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Given that the parser produces a typed AST, any changes to the AST will technically be breaking and thus will result in a `0.(N+1)` version. We document changes that break via addition as "Added".
 
 ## [Unreleased]
-Check https://github.com/andygrove/sqlparser-rs/commits/master for undocumented changes.
+Check https://github.com/andygrove/sqlparser-rs/commits/main for undocumented changes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 Given that the parser produces a typed AST, any changes to the AST will technically be breaking and thus will result in a `0.(N+1)` version. We document changes that break via addition as "Added".
 
 ## [Unreleased]
-Check https://github.com/andygrove/sqlparser-rs/commits/main for undocumented changes.
+Check https://github.com/ballista-compute/sqlparser-rs/commits/main for undocumented changes.
 
 ### Changed
 
@@ -166,3 +166,4 @@ We don't have a changelog for the changes made in 2018, but thanks to @crw5996, 
 
 ## [0.1.0] - 2018-09-03
 Initial release
+

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/crates/v/sqlparser.svg)](https://crates.io/crates/sqlparser)
-[![Build Status](https://travis-ci.org/andygrove/sqlparser-rs.svg?branch=master)](https://travis-ci.org/andygrove/sqlparser-rs)
-[![Coverage Status](https://coveralls.io/repos/github/andygrove/sqlparser-rs/badge.svg?branch=master)](https://coveralls.io/github/andygrove/sqlparser-rs?branch=master)
+[![Build Status](https://travis-ci.org/andygrove/sqlparser-rs.svg?branch=main)](https://travis-ci.org/andygrove/sqlparser-rs)
+[![Coverage Status](https://coveralls.io/repos/github/andygrove/sqlparser-rs/badge.svg?branch=main)](https://coveralls.io/github/andygrove/sqlparser-rs?branch=main)
 [![Gitter Chat](https://badges.gitter.im/sqlparser-rs/community.svg)](https://gitter.im/sqlparser-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 The goal of this project is to build a SQL lexer and parser capable of parsing

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/crates/v/sqlparser.svg)](https://crates.io/crates/sqlparser)
-[![Build Status](https://travis-ci.org/andygrove/sqlparser-rs.svg?branch=main)](https://travis-ci.org/andygrove/sqlparser-rs)
-[![Coverage Status](https://coveralls.io/repos/github/andygrove/sqlparser-rs/badge.svg?branch=main)](https://coveralls.io/github/andygrove/sqlparser-rs?branch=main)
+[![Build Status](https://travis-ci.org/ballista-compute/sqlparser-rs.svg?branch=main)](https://travis-ci.org/ballista-computee/sqlparser-rs)
+[![Coverage Status](https://coveralls.io/repos/github/ballista-compute/sqlparser-rs/badge.svg?branch=main)](https://coveralls.io/github/ballista-compute/sqlparser-rs?branch=main)
 [![Gitter Chat](https://badges.gitter.im/sqlparser-rs/community.svg)](https://gitter.im/sqlparser-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 The goal of this project is to build a SQL lexer and parser capable of parsing
@@ -123,7 +123,7 @@ resources.
 
 [tdop-tutorial]: https://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing
 [`cargo fmt`]: https://github.com/rust-lang/rustfmt#on-the-stable-toolchain
-[current issues]: https://github.com/andygrove/sqlparser-rs/issues
+[current issues]: https://github.com/ballista-compute/sqlparser-rs/issues
 [DataFusion]: https://github.com/apache/arrow/tree/master/rust/datafusion
 [LocustDB]: https://github.com/cswinter/LocustDB
 [Pratt Parser]: https://tdop.github.io/

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2878,7 +2878,7 @@ fn parse_start_transaction() {
     verified_stmt("START TRANSACTION ISOLATION LEVEL REPEATABLE READ");
     verified_stmt("START TRANSACTION ISOLATION LEVEL SERIALIZABLE");
 
-    // Regression test for https://github.com/andygrove/sqlparser-rs/pull/139,
+    // Regression test for https://github.com/ballista-compute/sqlparser-rs/pull/139,
     // in which START TRANSACTION would fail to parse if followed by a statement
     // terminator.
     assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -230,7 +230,7 @@ fn parse_create_table_with_inherit() {
 #[test]
 fn parse_create_table_empty() {
     // Zero-column tables are weird, but supported by at least PostgreSQL.
-    // <https://github.com/andygrove/sqlparser-rs/pull/94>
+    // <https://github.com/ballista-compute/sqlparser-rs/pull/94>
     let _ = pg_and_generic().verified_stmt("CREATE TABLE t ()");
 }
 


### PR DESCRIPTION
This updates references to our mainline branch to point to `main`.

Related to: #213.