### PR TITLE
Implement ASSERT statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -552,9 +552,11 @@ pub enum Statement {
     /// CREATE SCHEMA
     CreateSchema { schema_name: ObjectName },
 
-    // ASSERT <condition> [, <message>]
+    /// ASSERT <condition> [AS <message>]
     Assert {
         condition: Box<Expr>,
+        // AS or ,
+        separator: String,
         message: Option<Box<Expr>>,
     },
 }
@@ -816,11 +818,15 @@ impl fmt::Display for Statement {
                 write!(f, "ROLLBACK{}", if *chain { " AND CHAIN" } else { "" },)
             }
             Statement::CreateSchema { schema_name } => write!(f, "CREATE SCHEMA {}", schema_name),
-            Statement::Assert { condition, message } => {
+            Statement::Assert {
+                condition,
+                separator,
+                message,
+            } => {
                 write!(f, "ASSERT {}", condition)?;
 
                 if let Some(m) = message {
-                    write!(f, ", {}", m)?;
+                    write!(f, " {} {}", separator, m)?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -551,6 +551,12 @@ pub enum Statement {
     Rollback { chain: bool },
     /// CREATE SCHEMA
     CreateSchema { schema_name: ObjectName },
+
+    // ASSERT <condition> [, <message>]
+    Assert {
+        condition: Box<Expr>,
+        message: Option<Box<Expr>>,
+    },
 }
 
 impl fmt::Display for Statement {
@@ -810,6 +816,14 @@ impl fmt::Display for Statement {
                 write!(f, "ROLLBACK{}", if *chain { " AND CHAIN" } else { "" },)
             }
             Statement::CreateSchema { schema_name } => write!(f, "CREATE SCHEMA {}", schema_name),
+            Statement::Assert { condition, message } => {
+                write!(f, "ASSERT {}", condition)?;
+
+                if let Some(m) = message {
+                    write!(f, ", {}", m)?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -554,10 +554,10 @@ pub enum Statement {
 
     /// ASSERT <condition> [AS <message>]
     Assert {
-        condition: Box<Expr>,
+        condition: Expr,
         // AS or ,
         separator: String,
-        message: Option<Box<Expr>>,
+        message: Option<Expr>,
     },
 }
 

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -79,6 +79,7 @@ define_keywords!(
     AS,
     ASC,
     ASENSITIVE,
+    ASSERT,
     ASYMMETRIC,
     AT,
     ATOMIC,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -182,10 +182,11 @@ impl Parser {
     }
     pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
         let condition = self.parse_expr()?;
-        let mut message = None;
-        if self.consume_token(&Token::Comma) {
-            message = Some(Box::new(self.parse_expr()?));
-        }
+        let message = if self.consume_token(&Token::Comma) || self.parse_keyword(Keyword::AS) {
+            Some(Box::new(self.parse_expr()?))
+        } else {
+            None
+        };
 
         Ok(Statement::Assert {
             condition: Box::new(condition),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -182,14 +182,17 @@ impl Parser {
     }
     pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
         let condition = self.parse_expr()?;
-        let message = if self.consume_token(&Token::Comma) || self.parse_keyword(Keyword::AS) {
-            Some(Box::new(self.parse_expr()?))
+        let (separator, message) = if self.consume_token(&Token::Comma) {
+            (",".to_string(), Some(Box::new(self.parse_expr()?)))
+        } else if self.parse_keyword(Keyword::AS) {
+            ("AS".to_string(), Some(Box::new(self.parse_expr()?)))
         } else {
-            None
+            ("".to_string(), None)
         };
 
         Ok(Statement::Assert {
             condition: Box::new(condition),
+            separator,
             message,
         })
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -183,15 +183,15 @@ impl Parser {
     pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
         let condition = self.parse_expr()?;
         let (separator, message) = if self.consume_token(&Token::Comma) {
-            (",".to_string(), Some(Box::new(self.parse_expr()?)))
+            (",".to_string(), Some(self.parse_expr()?))
         } else if self.parse_keyword(Keyword::AS) {
-            ("AS".to_string(), Some(Box::new(self.parse_expr()?)))
+            ("AS".to_string(), Some(self.parse_expr()?))
         } else {
             ("".to_string(), None)
         };
 
         Ok(Statement::Assert {
-            condition: Box::new(condition),
+            condition,
             separator,
             message,
         })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -148,6 +148,7 @@ impl Parser {
                 Keyword::BEGIN => Ok(self.parse_begin()?),
                 Keyword::COMMIT => Ok(self.parse_commit()?),
                 Keyword::ROLLBACK => Ok(self.parse_rollback()?),
+                Keyword::ASSERT => Ok(self.parse_assert()?),
                 _ => self.expected("an SQL statement", Token::Word(w)),
             },
             Token::LParen => {
@@ -178,6 +179,18 @@ impl Parser {
             expr = self.parse_infix(expr, next_precedence)?;
         }
         Ok(expr)
+    }
+    pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
+        let condition = self.parse_expr()?;
+        let mut message = None;
+        if self.consume_token(&Token::Comma) {
+            message = Some(Box::new(self.parse_expr()?));
+        }
+
+        Ok(Statement::Assert {
+            condition: Box::new(condition),
+            message,
+        })
     }
 
     /// Parse an expression prefix

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1187,7 +1187,7 @@ fn parse_assert_message() {
             separator,
         } => {
             assert_eq!(separator, "AS");
-            match *message {
+            match message {
                 Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in table"),
                 _ => unreachable!(),
             };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1173,10 +1173,10 @@ fn parse_assert() {
 
 #[test]
 fn parse_assert_message() {
-    let sql = "ASSERT (SELECT COUNT(*) FROM table) > 0, 'No rows in table'";
+    let sql = "ASSERT (SELECT COUNT(*) FROM table) > 0 AS 'No rows in table'";
     let ast = one_statement_parses_to(
         sql,
-        "ASSERT (SELECT COUNT(*) FROM table) > 0, 'No rows in table'",
+        "ASSERT (SELECT COUNT(*) FROM table) > 0 AS 'No rows in table'",
     );
     match ast {
         Statement::Assert {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1184,7 +1184,7 @@ fn parse_assert_message() {
         Statement::Assert {
             condition: _condition,
             message: Some(message),
-            separator
+            separator,
         } => {
             assert_eq!(separator, "AS");
             match *message {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1163,9 +1163,11 @@ fn parse_assert() {
     match ast {
         Statement::Assert {
             condition: _condition,
+            separator,
             message,
         } => {
-            assert!(message.is_none());
+            assert_eq!(message, None);
+            assert_eq!(separator, "");
         }
         _ => unreachable!(),
     }
@@ -1182,7 +1184,9 @@ fn parse_assert_message() {
         Statement::Assert {
             condition: _condition,
             message: Some(message),
+            separator
         } => {
+            assert_eq!(separator, "AS");
             match *message {
                 Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in table"),
                 _ => unreachable!(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1157,6 +1157,42 @@ fn parse_create_table_with_multiple_on_delete_fails() {
 }
 
 #[test]
+fn parse_assert() {
+    let sql = "ASSERT (SELECT COUNT(*) FROM table) > 0";
+    let ast = one_statement_parses_to(sql, "ASSERT (SELECT COUNT(*) FROM table) > 0");
+    match ast {
+        Statement::Assert {
+            condition: _condition,
+            message,
+        } => {
+            assert!(message.is_none());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_assert_message() {
+    let sql = "ASSERT (SELECT COUNT(*) FROM table) > 0, 'No rows in table'";
+    let ast = one_statement_parses_to(
+        sql,
+        "ASSERT (SELECT COUNT(*) FROM table) > 0, 'No rows in table'",
+    );
+    match ast {
+        Statement::Assert {
+            condition: _condition,
+            message: Some(message),
+        } => {
+            match *message {
+                Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in table"),
+                _ => unreachable!(),
+            };
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_schema() {
     let sql = "CREATE SCHEMA X";
 


### PR DESCRIPTION
Issue: https://github.com/ballista-compute/sqlparser-rs/issues/225

See:
https://cloud.google.com/bigquery/docs/reference/standard-sql/debugging-statements
https://www.postgresql.org/docs/10/plpgsql-errors-and-messages.html

PostgreSQL supports an arbitrary expression as optional second message, so made that an expression as well.