### PR TITLE
Remove PostgreSQL version of assert

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -556,7 +556,6 @@ pub enum Statement {
     Assert {
         condition: Expr,
         // AS or ,
-        separator: String,
         message: Option<Expr>,
     },
 }
@@ -818,15 +817,11 @@ impl fmt::Display for Statement {
                 write!(f, "ROLLBACK{}", if *chain { " AND CHAIN" } else { "" },)
             }
             Statement::CreateSchema { schema_name } => write!(f, "CREATE SCHEMA {}", schema_name),
-            Statement::Assert {
-                condition,
-                separator,
-                message,
-            } => {
+            Statement::Assert { condition, message } => {
                 write!(f, "ASSERT {}", condition)?;
 
                 if let Some(m) = message {
-                    write!(f, " {} {}", separator, m)?;
+                    write!(f, " AS {}", m)?;
                 }
                 Ok(())
             }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -555,7 +555,6 @@ pub enum Statement {
     /// ASSERT <condition> [AS <message>]
     Assert {
         condition: Expr,
-        // AS or ,
         message: Option<Expr>,
     },
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -182,19 +182,13 @@ impl Parser {
     }
     pub fn parse_assert(&mut self) -> Result<Statement, ParserError> {
         let condition = self.parse_expr()?;
-        let (separator, message) = if self.consume_token(&Token::Comma) {
-            (",".to_string(), Some(self.parse_expr()?))
-        } else if self.parse_keyword(Keyword::AS) {
-            ("AS".to_string(), Some(self.parse_expr()?))
+        let message = if self.parse_keyword(Keyword::AS) {
+            Some(self.parse_expr()?)
         } else {
-            ("".to_string(), None)
+            None
         };
 
-        Ok(Statement::Assert {
-            condition,
-            separator,
-            message,
-        })
+        Ok(Statement::Assert { condition, message })
     }
 
     /// Parse an expression prefix

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1163,11 +1163,9 @@ fn parse_assert() {
     match ast {
         Statement::Assert {
             condition: _condition,
-            separator,
             message,
         } => {
             assert_eq!(message, None);
-            assert_eq!(separator, "");
         }
         _ => unreachable!(),
     }
@@ -1184,9 +1182,7 @@ fn parse_assert_message() {
         Statement::Assert {
             condition: _condition,
             message: Some(message),
-            separator,
         } => {
-            assert_eq!(separator, "AS");
             match message {
                 Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in table"),
                 _ => unreachable!(),


### PR DESCRIPTION
I linked earlier to this page but didn't notice this was part of PL/pgSQL (so no valid SQL statement in PostgreSQL).

In that case we can better remove the postgres part and simplify the code a bit.
https://www.postgresql.org/docs/10/plpgsql-errors-and-messages.html

