### PR TITLE
automate crate publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,3 +63,16 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-crate:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v2
+      - name: Publish
+        shell: bash
+        run: |
+          cargo publish --token ${{ secrets.CRATES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ serde_json = { version = "1.0", optional = true }
 [dev-dependencies]
 simple_logger = "1.0.1"
 matches = "0.1"
+
+[package.metadata.release]
+disable-publish = true

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,32 @@
+# Releasing
+
+Releasing, i.e. crate publishing, has been automated via GitHub Actions.
+
+In order to author a new release, you simply tag the desired revision and push
+the resulting tag.
+
+**Before releasing** ensure `CHANGELOG.md` is updated appropriately as well as
+`Cargo.toml`.
+
+## Process
+
+Please ensure you follow the correct format when creating new tags. For
+instance:
+
+```
+git tag -a '0.6.0' -m '(cargo-release) sqlparser version 0.6.0'
+```
+
+This will create a new tag, `0.6.0` which the message,
+`(cargo-release) sqlparser version 0.6.0`.
+
+Once the tag is created, pushing the tag upstream will trigger a publishing
+process to crates.io. Now to push our example tag:
+
+```
+git push origin 0.6.0
+```
+
+(Note that this process is fully automated; credentials
+for authoring in this way are securely stored in the repo secrets as
+`CRATE_TOKEN`.)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,20 +2,25 @@
 
 Releasing, i.e. crate publishing, has been automated via GitHub Actions.
 
-In order to author a new release, you simply tag the desired revision and push
-the resulting tag.
+We use the [`cargo release`](https://github.com/sunng87/cargo-release)
+subcommand to ensure correct versioning. Install via:
 
-**Before releasing** ensure `CHANGELOG.md` is updated appropriately as well as
-`Cargo.toml`.
+```
+$ cargo install cargo-release
+```
+
+**Before releasing** ensure `CHANGELOG.md` is updated appropriately.
 
 ## Process
 
-Please ensure you follow the correct format when creating new tags. For
-instance:
+Using `cargo-release` we can author a new minor release like so:
 
 ```
-git tag -a '0.6.0' -m '(cargo-release) sqlparser version 0.6.0'
+$ cargo release minor --skip-publish
 ```
+
+**Ensure publishing is skipped** since pushing the resulting tag upstream will
+handle crate publishing automatically.
 
 This will create a new tag, `0.6.0` with the message,
 `(cargo-release) sqlparser version 0.6.0`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,7 +17,7 @@ instance:
 git tag -a '0.6.0' -m '(cargo-release) sqlparser version 0.6.0'
 ```
 
-This will create a new tag, `0.6.0` which the message,
+This will create a new tag, `0.6.0` with the message,
 `(cargo-release) sqlparser version 0.6.0`.
 
 Once the tag is created, pushing the tag upstream will trigger a publishing


### PR DESCRIPTION
This introduces a new section of the GitHub Actions workflow which will
publish the crate upon a new tag being pushed. Note that this requires a
new project secret, `CRATES_TOKEN`.