### PR TITLE
Support create or replace view/table

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -462,25 +462,25 @@ pub enum Statement {
     },
     /// CREATE VIEW
     CreateView {
+        or_replace: bool,
+        materialized: bool,
         /// View name
         name: ObjectName,
         columns: Vec<Ident>,
         query: Box<Query>,
-        materialized: bool,
-        or_replace: bool,
         with_options: Vec<SqlOption>,
     },
     /// CREATE TABLE
     CreateTable {
+        or_replace: bool,
+        external: bool,
+        if_not_exists: bool,
         /// Table name
         name: ObjectName,
         /// Optional schema
         columns: Vec<ColumnDef>,
         constraints: Vec<TableConstraint>,
         with_options: Vec<SqlOption>,
-        or_replace: bool,
-        if_not_exists: bool,
-        external: bool,
         file_format: Option<FileFormat>,
         location: Option<String>,
         query: Option<Box<Query>>,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -464,6 +464,7 @@ pub enum Statement {
     CreateView {
         /// View name
         name: ObjectName,
+        or_replace: bool,
         columns: Vec<Ident>,
         query: Box<Query>,
         materialized: bool,
@@ -630,12 +631,18 @@ impl fmt::Display for Statement {
             }
             Statement::CreateView {
                 name,
+                or_replace,
                 columns,
                 query,
                 materialized,
                 with_options,
             } => {
                 write!(f, "CREATE")?;
+
+                if *or_replace {
+                    write!(f, " OR REPLACE")?;
+                }
+
                 if *materialized {
                     write!(f, " MATERIALIZED")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -464,10 +464,10 @@ pub enum Statement {
     CreateView {
         /// View name
         name: ObjectName,
-        or_replace: bool,
         columns: Vec<Ident>,
         query: Box<Query>,
         materialized: bool,
+        or_replace: bool,
         with_options: Vec<SqlOption>,
     },
     /// CREATE TABLE

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -477,6 +477,7 @@ pub enum Statement {
         columns: Vec<ColumnDef>,
         constraints: Vec<TableConstraint>,
         with_options: Vec<SqlOption>,
+        or_replace: bool,
         if_not_exists: bool,
         external: bool,
         file_format: Option<FileFormat>,
@@ -656,6 +657,7 @@ impl fmt::Display for Statement {
                 columns,
                 constraints,
                 with_options,
+                or_replace,
                 if_not_exists,
                 external,
                 file_format,
@@ -672,7 +674,8 @@ impl fmt::Display for Statement {
                 //   `CREATE TABLE t (a INT) AS SELECT a from t2`
                 write!(
                     f,
-                    "CREATE {external}TABLE {if_not_exists}{name}",
+                    "CREATE {or_replace}{external}TABLE {if_not_exists}{name}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     external = if *external { "EXTERNAL " } else { "" },
                     if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
                     name = name,

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -343,6 +343,7 @@ define_keywords!(
     RELEASE,
     RENAME,
     REPEATABLE,
+    REPLACE,
     RESTRICT,
     RESULT,
     RETURN,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -990,15 +990,20 @@ impl Parser {
         let or_replace = self.parse_keywords(&[Keyword::OR, Keyword::REPLACE]);
         if self.parse_keyword(Keyword::TABLE) {
             self.parse_create_table(or_replace)
-        } else if self.parse_keyword(Keyword::INDEX) {
-            self.parse_create_index(false)
-        } else if self.parse_keywords(&[Keyword::UNIQUE, Keyword::INDEX]) {
-            self.parse_create_index(true)
         } else if self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW) {
             self.prev_token();
             self.parse_create_view(or_replace)
         } else if self.parse_keyword(Keyword::EXTERNAL) {
             self.parse_create_external_table(or_replace)
+        } else if or_replace {
+            self.expected(
+                "[EXTERNAL] TABLE or [MATERIALIZED] VIEW after CREATE OR REPLACE",
+                self.peek_token(),
+            )
+        } else if self.parse_keyword(Keyword::INDEX) {
+            self.parse_create_index(false)
+        } else if self.parse_keywords(&[Keyword::UNIQUE, Keyword::INDEX]) {
+            self.parse_create_index(true)
         } else if self.parse_keyword(Keyword::VIRTUAL) {
             self.parse_create_virtual_table()
         } else if self.parse_keyword(Keyword::SCHEMA) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -987,26 +987,18 @@ impl Parser {
 
     /// Parse a SQL CREATE statement
     pub fn parse_create(&mut self) -> Result<Statement, ParserError> {
+        let or_replace = self.parse_keywords(&[Keyword::OR, Keyword::REPLACE]);
         if self.parse_keyword(Keyword::TABLE) {
-            self.parse_create_table(false)
-        } else if self.parse_keywords(&[Keyword::OR, Keyword::REPLACE, Keyword::TABLE]) {
-            self.parse_create_table(true)
+            self.parse_create_table(or_replace)
         } else if self.parse_keyword(Keyword::INDEX) {
             self.parse_create_index(false)
         } else if self.parse_keywords(&[Keyword::UNIQUE, Keyword::INDEX]) {
             self.parse_create_index(true)
         } else if self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW) {
             self.prev_token();
-            self.parse_create_view(false)
-        } else if self.parse_keywords(&[Keyword::OR, Keyword::REPLACE])
-            && (self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW))
-        {
-            self.prev_token();
-            self.parse_create_view(true)
+            self.parse_create_view(or_replace)
         } else if self.parse_keyword(Keyword::EXTERNAL) {
-            self.parse_create_external_table(false)
-        } else if self.parse_keywords(&[Keyword::OR, Keyword::REPLACE, Keyword::EXTERNAL]) {
-            self.parse_create_external_table(true)
+            self.parse_create_external_table(or_replace)
         } else if self.parse_keyword(Keyword::VIRTUAL) {
             self.parse_create_virtual_table()
         } else if self.parse_keyword(Keyword::SCHEMA) {
@@ -1098,10 +1090,10 @@ impl Parser {
         // Optional `WITH [ CASCADED | LOCAL ] CHECK OPTION` is widely supported here.
         Ok(Statement::CreateView {
             name,
-            or_replace,
             columns,
             query,
             materialized,
+            or_replace,
             with_options,
         })
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1080,7 +1080,7 @@ impl Parser {
     pub fn parse_create_view(&mut self, or_replace: bool) -> Result<Statement, ParserError> {
         let materialized = self.parse_keyword(Keyword::MATERIALIZED);
         self.expect_keyword(Keyword::VIEW)?;
-        // Many dialects support `OR REPLACE` | `OR ALTER` right after `CREATE`, but we don't (yet).
+        // Many dialects support `OR ALTER` right after `CREATE`, but we don't (yet).
         // ANSI SQL and Postgres support RECURSIVE here, but we don't support it either.
         let name = self.parse_object_name()?;
         let columns = self.parse_parenthesized_column_list(Optional)?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1415,17 +1415,15 @@ fn parse_create_or_replace_external_table() {
             assert_eq!("uk_cities", name.to_string());
             assert_eq!(
                 columns,
-                vec![
-                    ColumnDef {
-                        name: "name".into(),
-                        data_type: DataType::Varchar(Some(100)),
-                        collation: None,
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::NotNull
-                        }],
-                    },
-                ]
+                vec![ColumnDef {
+                    name: "name".into(),
+                    data_type: DataType::Varchar(Some(100)),
+                    collation: None,
+                    options: vec![ColumnOptionDef {
+                        name: None,
+                        option: ColumnOption::NotNull
+                    }],
+                },]
             );
             assert!(constraints.is_empty());
 
@@ -1440,7 +1438,6 @@ fn parse_create_or_replace_external_table() {
         _ => unreachable!(),
     }
 }
-
 
 #[test]
 fn parse_create_external_table_lowercase() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2520,6 +2520,7 @@ fn parse_create_view() {
             name,
             columns,
             query,
+            or_replace,
             materialized,
             with_options,
         } => {
@@ -2527,6 +2528,7 @@ fn parse_create_view() {
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(!materialized);
+            assert!(!or_replace);
             assert_eq!(with_options, vec![]);
         }
         _ => unreachable!(),
@@ -2563,6 +2565,7 @@ fn parse_create_view_with_columns() {
         Statement::CreateView {
             name,
             columns,
+            or_replace,
             with_options,
             query,
             materialized,
@@ -2572,6 +2575,29 @@ fn parse_create_view_with_columns() {
             assert_eq!(with_options, vec![]);
             assert_eq!("SELECT 1, 2", query.to_string());
             assert!(!materialized);
+            assert!(!or_replace)
+        }
+        _ => unreachable!(),
+    }
+}
+#[test]
+fn parse_create_or_replace_view() {
+    let sql = "CREATE OR REPLACE VIEW v AS SELECT 1";
+    match verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            or_replace,
+            with_options,
+            query,
+            materialized,
+        } => {
+            assert_eq!("v", name.to_string());
+            assert_eq!(columns, vec![]);
+            assert_eq!(with_options, vec![]);
+            assert_eq!("SELECT 1", query.to_string());
+            assert!(!materialized);
+            assert!(or_replace)
         }
         _ => unreachable!(),
     }
@@ -2583,6 +2609,7 @@ fn parse_create_materialized_view() {
     match verified_stmt(sql) {
         Statement::CreateView {
             name,
+            or_replace,
             columns,
             query,
             materialized,
@@ -2593,6 +2620,7 @@ fn parse_create_materialized_view() {
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(materialized);
             assert_eq!(with_options, vec![]);
+            assert!(!or_replace);
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Adds support for create or replace (external) table

https://github.com/ballista-compute/sqlparser-rs/issues/228

Examples:
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language
https://docs.snowflake.com/en/sql-reference/sql/create-external-table.html
