### PR TITLE
Use dialects in the parser for support snowflake aliasing syntax

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -235,11 +235,11 @@ pub enum TableFactor {
         subquery: Box<Query>,
         alias: Option<TableAlias>,
     },
-    /// Represents a parenthesized table factor. The SQL spec only allows a
-    /// join expression (`(foo <JOIN> bar [ <JOIN> baz ... ])`) to be nested,
-    /// possibly several times, but the parser also accepts the non-standard
-    /// nesting of bare tables (`table_with_joins.joins.is_empty()`), so the
-    /// name `NestedJoin` is a bit of misnomer.
+    /// The inner `TableWithJoins` can have no joins only if its
+    /// `relation` is itself a `TableFactor::NestedJoin`.
+    /// Some dialects allow nesting lone `Table`/`Derived` in parens,
+    /// e.g. `FROM (mytable)`, but we don't expose the presence of these
+    /// extraneous parens in the AST.
     NestedJoin(Box<TableWithJoins>),
 }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -16,7 +16,7 @@ pub mod keywords;
 mod mssql;
 mod mysql;
 mod postgresql;
-
+mod snowflake;
 use std::fmt::Debug;
 
 pub use self::ansi::AnsiDialect;
@@ -24,6 +24,7 @@ pub use self::generic::GenericDialect;
 pub use self::mssql::MsSqlDialect;
 pub use self::mysql::MySqlDialect;
 pub use self::postgresql::PostgreSqlDialect;
+pub use self::snowflake::SnowflakeDialect;
 
 pub trait Dialect: Debug {
     /// Determine if a character starts a quoted identifier. The default
@@ -38,4 +39,8 @@ pub trait Dialect: Debug {
     fn is_identifier_start(&self, ch: char) -> bool;
     /// Determine if a character is a valid unquoted identifier character
     fn is_identifier_part(&self, ch: char) -> bool;
+
+    fn alllow_single_table_in_parenthesis(&self) -> bool {
+        false
+    }
 }

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1,0 +1,26 @@
+use crate::dialect::Dialect;
+
+#[derive(Debug, Default)]
+pub struct SnowflakeDialect;
+
+impl Dialect for SnowflakeDialect {
+    //Revisit: currently copied from Genric dialect
+    fn is_identifier_start(&self, ch: char) -> bool {
+        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '#' || ch == '@'
+    }
+
+    //Revisit: currently copied from Genric dialect
+    fn is_identifier_part(&self, ch: char) -> bool {
+        (ch >= 'a' && ch <= 'z')
+            || (ch >= 'A' && ch <= 'Z')
+            || (ch >= '0' && ch <= '9')
+            || ch == '@'
+            || ch == '$'
+            || ch == '#'
+            || ch == '_'
+    }
+
+    fn alllow_single_table_in_parenthesis(&self) -> bool {
+        true
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -53,7 +53,7 @@ impl TestedDialects {
         self.one_of_identical_results(|dialect| {
             let mut tokenizer = Tokenizer::new(dialect, sql);
             let tokens = tokenizer.tokenize().unwrap();
-            f(&mut Parser::new(tokens))
+            f(&mut Parser::new(tokens, dialect))
         })
     }
 
@@ -104,7 +104,9 @@ impl TestedDialects {
     /// Ensures that `sql` parses as an expression, and is not modified
     /// after a serialization round-trip.
     pub fn verified_expr(&self, sql: &str) -> Expr {
-        let ast = self.run_parser_method(sql, Parser::parse_expr).unwrap();
+        let ast = self
+            .run_parser_method(sql, |parser| parser.parse_expr())
+            .unwrap();
         assert_eq!(sql, &ast.to_string(), "round-tripping without changes");
         ast
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2277,7 +2277,7 @@ fn parse_join_nesting() {
     // Nesting a subquery in parentheses is non-standard, but supported in Snowflake SQL
     let res = parse_sql_statements("SELECT * FROM ((SELECT 1) AS t)");
     assert_eq!(
-        ParserError::ParserError("Expected joined table, found: EOF".to_string()),
+        ParserError::ParserError("Expected joined table, found: )".to_string()),
         res.unwrap_err()
     );
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1,0 +1,152 @@
+use sqlparser::ast::*;
+use sqlparser::dialect::SnowflakeDialect;
+use sqlparser::parser::ParserError;
+use sqlparser::test_utils::*;
+
+fn table_alias(alias: &str) -> TableAlias {
+    TableAlias {
+        name: Ident {
+            value: alias.to_owned(),
+            quote_style: None,
+        },
+        columns: Vec::new(),
+    }
+}
+
+fn table(name: impl Into<String>, alias: Option<TableAlias>) -> TableFactor {
+    TableFactor::Table {
+        name: ObjectName(vec![Ident::new(name.into())]),
+        alias,
+        args: vec![],
+        with_hints: vec![],
+    }
+}
+
+fn join(relation: TableFactor) -> Join {
+    Join {
+        relation,
+        join_operator: JoinOperator::Inner(JoinConstraint::Natural),
+    }
+}
+
+macro_rules! nest {
+    ($base:expr $(, $join:expr)*) => {
+        TableFactor::NestedJoin(Box::new(TableWithJoins {
+            relation: $base,
+            joins: vec![$(join($join)),*]
+        }))
+    };
+}
+
+fn sf() -> TestedDialects {
+    TestedDialects {
+        dialects: vec![Box::new(SnowflakeDialect {})],
+    }
+}
+
+fn get_from_section_from_select_query(query: &str) -> Vec<TableWithJoins> {
+    let statement = sf().parse_sql_statements(query).unwrap()[0].clone();
+
+    let query = match statement {
+        Statement::Query(query) => query,
+        _ => panic!("Not a query"),
+    };
+
+    let select = match query.body {
+        SetExpr::Select(select) => select,
+        _ => panic!("not a select query"),
+    };
+
+    select.from.clone()
+}
+
+#[test]
+fn test_sf_derives_single_table_in_parenthesis() {
+    let from = get_from_section_from_select_query("SELECT * FROM (((SELECT 1) AS t))");
+
+    assert_eq!(
+        from[0].relation,
+        TableFactor::Derived {
+            lateral: false,
+            subquery: Box::new(sf().verified_query("SELECT 1")),
+            alias: Some(TableAlias {
+                name: "t".into(),
+                columns: vec![],
+            })
+        }
+    );
+}
+
+#[test]
+fn test_single_table_in_parenthesis() {
+    //Parenthesized table names are non-standard, but supported in Snowflake SQL
+    let from = get_from_section_from_select_query("SELECT * FROM (a NATURAL JOIN (b))");
+
+    assert_eq!(from[0].relation, nest!(table("a", None), table("b", None)));
+
+    let from = get_from_section_from_select_query("SELECT * FROM (a NATURAL JOIN ((b)))");
+    assert_eq!(from[0].relation, nest!(table("a", None), table("b", None)));
+}
+
+#[test]
+fn test_single_table_in_parenthesis_with_alias() {
+    let sql = "SELECT * FROM (a NATURAL JOIN (b) c )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(table("a", None), table("b", Some(table_alias("c"))))
+    );
+
+    let sql = "SELECT * FROM (a NATURAL JOIN ((b)) c )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(table("a", None), table("b", Some(table_alias("c"))))
+    );
+
+    let sql = "SELECT * FROM (a NATURAL JOIN ( (b) c ) )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(table("a", None), table("b", Some(table_alias("c"))))
+    );
+
+    let sql = "SELECT * FROM (a NATURAL JOIN ( (b) as c ) )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(table("a", None), table("b", Some(table_alias("c"))))
+    );
+
+    let sql = "SELECT * FROM (a alias1 NATURAL JOIN ( (b) c ) )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(
+            table("a", Some(table_alias("alias1"))),
+            table("b", Some(table_alias("c")))
+        )
+    );
+
+    let sql = "SELECT * FROM (a as alias1 NATURAL JOIN ( (b) as c ) )";
+    let table_with_joins = get_from_section_from_select_query(sql)[0].clone();
+    assert_eq!(
+        table_with_joins.relation,
+        nest!(
+            table("a", Some(table_alias("alias1"))),
+            table("b", Some(table_alias("c")))
+        )
+    );
+
+    let res = sf().parse_sql_statements("SELECT * FROM (a NATURAL JOIN b) c");
+    assert_eq!(
+        ParserError::ParserError("Expected end of statement, found: c".to_string()),
+        res.unwrap_err()
+    );
+
+    let res = sf().parse_sql_statements("SELECT * FROM (a b) c");
+    assert_eq!(
+        ParserError::ParserError("duplicate alias b".to_string()),
+        res.unwrap_err()
+    );
+}


### PR DESCRIPTION
Snowflake DB allow single table to be within parenthesis.
This behaviour is diffrent than other DB ,
and it has some impact on the parsing table factor.

For supporting we do the following :
1. Add refrence to the dialect in the parser
2. Add Snowflake dialect
3. add function to the dialect trait the identify if single table inside parenthesis allowed
4. When parsing table factor in the allow/deny single table inside parenthesis according to dialect