### PR TITLE
Don't fail parsing ALTER TABLE ADD COLUMN ending with a semicolon

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1197,7 +1197,7 @@ impl Parser {
         let mut options = vec![];
         loop {
             match self.peek_token() {
-                Token::EOF | Token::Comma | Token::RParen => break,
+                Token::EOF | Token::Comma | Token::RParen | Token::SemiColon => break,
                 _ => options.push(self.parse_column_option_def()?),
             }
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1459,8 +1459,8 @@ fn parse_create_external_table_lowercase() {
 
 #[test]
 fn parse_alter_table() {
-    let add_column = "ALTER TABLE tab ADD COLUMN foo TEXT";
-    match verified_stmt(add_column) {
+    let add_column = "ALTER TABLE tab ADD COLUMN foo TEXT;";
+    match one_statement_parses_to(add_column, "ALTER TABLE tab ADD COLUMN foo TEXT") {
         Statement::AlterTable {
             name,
             operation: AlterTableOperation::AddColumn { column_def },


### PR DESCRIPTION
Fix `parse_column_def` https://github.com/ballista-compute/sqlparser-rs/issues/233

> ALTER TABLE tab ADD COLUMN foo TEXT;