### PR TITLE
Add support for named argument functions

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -873,12 +873,28 @@ impl fmt::Display for Assignment {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum FunctionArg {
+    Named { name: Ident, arg: Expr },
+    Unnamed(Expr),
+}
+
+impl fmt::Display for FunctionArg {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FunctionArg::Named { name, arg } => write!(f, "{} => {}", name, arg),
+            FunctionArg::Unnamed(unnamed_arg) => write!(f, "{}", unnamed_arg),
+        }
+    }
+}
+
 /// A function call
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Function {
     pub name: ObjectName,
-    pub args: Vec<Expr>,
+    pub args: Vec<FunctionArg>,
     pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -226,7 +226,7 @@ pub enum TableFactor {
         /// Arguments of a table-valued function, as supported by Postgres
         /// and MSSQL. Note that deprecated MSSQL `FROM foo (NOLOCK)` syntax
         /// will also be parsed as `args`.
-        args: Vec<Expr>,
+        args: Vec<FunctionArg>,
         /// MSSQL-specific `WITH (...)` hints such as NOLOCK.
         with_hints: Vec<Expr>,
     },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2203,11 +2203,24 @@ impl Parser {
         Ok(Assignment { id, value })
     }
 
-    pub fn parse_optional_args(&mut self) -> Result<Vec<Expr>, ParserError> {
+    fn parse_function_args(&mut self) -> Result<FunctionArg, ParserError> {
+        if self.peek_nth_token(1) == Token::RArrow {
+            let name = self.parse_identifier()?;
+
+            self.expect_token(&Token::RArrow)?;
+            let arg = self.parse_expr()?;
+
+            Ok(FunctionArg::Named { name, arg })
+        } else {
+            Ok(FunctionArg::Unnamed(self.parse_expr()?))
+        }
+    }
+
+    pub fn parse_optional_args(&mut self) -> Result<Vec<FunctionArg>, ParserError> {
         if self.consume_token(&Token::RParen) {
             Ok(vec![])
         } else {
-            let args = self.parse_comma_separated(Parser::parse_expr)?;
+            let args = self.parse_comma_separated(Parser::parse_function_args)?;
             self.expect_token(&Token::RParen)?;
             Ok(args)
         }


### PR DESCRIPTION
Add support for named argument function

This commit support functions with argument names.
the format is :
"Select some_function( a => exp, b => exp2 .. ) FROM table1
OR
"select * from table(function(a => exp)) f;"

see:
https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#named-argument-assignment-token
or example is snwflake db :
https://docs.snowflake.com/en/sql-reference/functions/flatten.html
 This commit does not belong to any branch on this repository.
