### PR TITLE
Support table function derived table

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -235,6 +235,11 @@ pub enum TableFactor {
         subquery: Box<Query>,
         alias: Option<TableAlias>,
     },
+    /// `TABLE(<expr>)[ AS <alias> ]`
+    TableFunction {
+        expr: Expr,
+        alias: Option<TableAlias>,
+    },
     /// Represents a parenthesized table factor. The SQL spec only allows a
     /// join expression (`(foo <JOIN> bar [ <JOIN> baz ... ])`) to be nested,
     /// possibly several times, but the parser also accepts the non-standard
@@ -273,6 +278,13 @@ impl fmt::Display for TableFactor {
                     write!(f, "LATERAL ")?;
                 }
                 write!(f, "({})", subquery)?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {}", alias)?;
+                }
+                Ok(())
+            }
+            TableFactor::TableFunction { expr, alias } => {
+                write!(f, "TABLE({})", expr)?;
                 if let Some(alias) = alias {
                     write!(f, " AS {}", alias)?;
                 }


### PR DESCRIPTION
Support `TABLE(...)` syntax in `FROM`, for example:

    select * from TABLE(SOME_FUNCTION(some_arg))

The ANSI spec allows routine invocations (and some other kinds of expressions we don't currently support) inside TABLE:
https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#PTF-derived-table
https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#table-function-derived-table