### PR TITLE
[snowflake] Support `FROM (table_name) alias`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -242,9 +242,10 @@ pub enum TableFactor {
     },
     /// Represents a parenthesized table factor. The SQL spec only allows a
     /// join expression (`(foo <JOIN> bar [ <JOIN> baz ... ])`) to be nested,
-    /// possibly several times, but the parser also accepts the non-standard
-    /// nesting of bare tables (`table_with_joins.joins.is_empty()`), so the
-    /// name `NestedJoin` is a bit of misnomer.
+    /// possibly several times.
+    ///
+    /// The parser may also accept non-standard nesting of bare tables for some
+    /// dialects, but the information about such nesting is stripped from AST.
     NestedJoin(Box<TableWithJoins>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,4 +43,5 @@ pub mod tokenizer;
 #[doc(hidden)]
 // This is required to make utilities accessible by both the crate-internal
 // unit-tests and by the integration tests <https://stackoverflow.com/a/44541071/1026>
+// External users are not supposed to rely on this module.
 pub mod test_utils;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2156,14 +2156,58 @@ impl<'a> Parser<'a> {
             // recently consumed does not start a derived table (cases 1, 2, or 4).
             // `maybe_parse` will ignore such an error and rewind to be after the opening '('.
 
-            // Inside the parentheses we expect to find a table factor
-            // followed by some joins or another level of nesting.
-            let table_and_joins = self.parse_table_and_joins()?;
-            self.expect_token(&Token::RParen)?;
-            // The SQL spec prohibits derived and bare tables from appearing
-            // alone in parentheses. We don't enforce this as some databases
-            // (e.g. Snowflake) allow such syntax.
-            Ok(TableFactor::NestedJoin(Box::new(table_and_joins)))
+            // Inside the parentheses we expect to find an (A) table factor
+            // followed by some joins or (B) another level of nesting.
+            let mut table_and_joins = self.parse_table_and_joins()?;
+
+            if !table_and_joins.joins.is_empty() {
+                self.expect_token(&Token::RParen)?;
+                Ok(TableFactor::NestedJoin(Box::new(table_and_joins))) // (A)
+            } else if let TableFactor::NestedJoin(_) = &table_and_joins.relation {
+                // (B): `table_and_joins` (what we found inside the parentheses)
+                // is a nested join `(foo JOIN bar)`, not followed by other joins.
+                self.expect_token(&Token::RParen)?;
+                Ok(TableFactor::NestedJoin(Box::new(table_and_joins)))
+            } else if dialect_of!(self is SnowflakeDialect | GenericDialect) {
+                // Dialect-specific behavior: Snowflake diverges from the
+                // standard and from most of the other implementations by
+                // allowing extra parentheses not only around a join (B), but
+                // around lone table names (e.g. `FROM (mytable [AS alias])`)
+                // and around derived tables (e.g. `FROM ((SELECT ...)
+                // [AS alias])`) as well.
+                self.expect_token(&Token::RParen)?;
+
+                if let Some(outer_alias) =
+                    self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?
+                {
+                    // Snowflake also allows specifying an alias *after* parens
+                    // e.g. `FROM (mytable) AS alias`
+                    match &mut table_and_joins.relation {
+                        TableFactor::Derived { alias, .. }
+                        | TableFactor::Table { alias, .. }
+                        | TableFactor::TableFunction { alias, .. } => {
+                            // but not `FROM (mytable AS alias1) AS alias2`.
+                            if let Some(inner_alias) = alias {
+                                return Err(ParserError::ParserError(format!(
+                                    "duplicate alias {}",
+                                    inner_alias
+                                )));
+                            }
+                            // Act as if the alias was specified normally next
+                            // to the table name: `(mytable) AS alias` ->
+                            // `(mytable AS alias)`
+                            alias.replace(outer_alias);
+                        }
+                        TableFactor::NestedJoin(_) => unreachable!(),
+                    };
+                }
+                // Do not store the extra set of parens in the AST
+                Ok(table_and_joins.relation)
+            } else {
+                // The SQL spec prohibits derived tables and bare tables from
+                // appearing alone in parentheses (e.g. `FROM (mytable)`)
+                self.expected("joined table", self.peek_token())
+            }
         } else {
             let name = self.parse_object_name()?;
             // Postgres, MSSQL: table-valued functions:

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,6 +10,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// This module contains internal utilities used for testing the library.
+/// While technically public, the library's users are not supposed to rely
+/// on this module, as it will change without notice.
+//
+// Integration tests (i.e. everything under `tests/`) import this
+// via `tests/test_utils/mod.rs`.
 use std::fmt::Debug;
 
 use super::ast::*;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -69,12 +69,18 @@ impl TestedDialects {
         // Parser::parse_sql(&**self.dialects.first().unwrap(), sql)
     }
 
-    /// Ensures that `sql` parses as a single statement, optionally checking
-    /// that converting AST back to string equals to `canonical` (unless an
-    /// empty canonical string is provided).
+    /// Ensures that `sql` parses as a single statement and returns it.
+    /// If non-empty `canonical` SQL representation is provided,
+    /// additionally asserts that parsing `sql` results in the same parse
+    /// tree as parsing `canonical`, and that serializing it back to string
+    /// results in the `canonical` representation.
     pub fn one_statement_parses_to(&self, sql: &str, canonical: &str) -> Statement {
         let mut statements = self.parse_sql_statements(&sql).unwrap();
         assert_eq!(statements.len(), 1);
+
+        if !canonical.is_empty() && sql != canonical {
+            assert_eq!(self.parse_sql_statements(&canonical).unwrap(), statements);
+        }
 
         let only_statement = statements.pop().unwrap();
         if !canonical.is_empty() {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -143,3 +143,19 @@ pub fn expr_from_projection(item: &SelectItem) -> &Expr {
 pub fn number(n: &'static str) -> Value {
     Value::Number(n.parse().unwrap())
 }
+
+pub fn table(name: impl Into<String>) -> TableFactor {
+    TableFactor::Table {
+        name: ObjectName(vec![Ident::new(name.into())]),
+        alias: None,
+        args: vec![],
+        with_hints: vec![],
+    }
+}
+
+pub fn join(relation: TableFactor) -> Join {
+    Join {
+        relation,
+        join_operator: JoinOperator::Inner(JoinConstraint::Natural),
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -156,6 +156,13 @@ pub fn number(n: &'static str) -> Value {
     Value::Number(n.parse().unwrap())
 }
 
+pub fn table_alias(name: impl Into<String>) -> Option<TableAlias> {
+    Some(TableAlias {
+        name: Ident::new(name),
+        columns: vec![],
+    })
+}
+
 pub fn table(name: impl Into<String>) -> TableFactor {
     TableFactor::Table {
         name: ObjectName(vec![Ident::new(name.into())]),

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+macro_rules! nest {
+    ($base:expr $(, $join:expr)*) => {
+        TableFactor::NestedJoin(Box::new(TableWithJoins {
+            relation: $base,
+            joins: vec![$(join($join)),*]
+        }))
+    };
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -19,14 +19,13 @@
 //! dialect-specific parsing rules).
 
 #[macro_use]
-#[path = "macros/mod.rs"]
-mod macros;
+mod test_utils;
+use test_utils::{all_dialects, expr_from_projection, join, number, only, table};
 
 use matches::assert_matches;
 use sqlparser::ast::*;
 use sqlparser::dialect::keywords::ALL_KEYWORDS;
 use sqlparser::parser::ParserError;
-use sqlparser::test_utils::{all_dialects, expr_from_projection, join, number, only, table};
 
 #[test]
 fn parse_insert_values() {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -20,7 +20,7 @@
 
 #[macro_use]
 mod test_utils;
-use test_utils::{all_dialects, expr_from_projection, join, number, only, table};
+use test_utils::{all_dialects, expr_from_projection, join, number, only, table, table_alias};
 
 use matches::assert_matches;
 use sqlparser::ast::*;
@@ -2128,13 +2128,6 @@ fn parse_cross_join() {
         },
         only(only(select.from).joins),
     );
-}
-
-fn table_alias(name: impl Into<String>) -> Option<TableAlias> {
-    Some(TableAlias {
-        name: Ident::new(name),
-        columns: vec![],
-    })
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -14,9 +14,12 @@
 //! Test SQL syntax specific to Microsoft's T-SQL. The parser based on the
 //! generic dialect is also tested (on the inputs it can handle).
 
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, MsSqlDialect};
-use sqlparser::test_utils::*;
 
 #[test]
 fn parse_mssql_identifiers() {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -11,13 +11,15 @@
 // limitations under the License.
 
 #![warn(clippy::all)]
-
 //! Test SQL syntax specific to MySQL. The parser based on the generic dialect
 //! is also tested (on the inputs it can handle).
 
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, MySqlDialect};
-use sqlparser::test_utils::*;
 use sqlparser::tokenizer::Token;
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -14,10 +14,13 @@
 //! Test SQL syntax specific to PostgreSQL. The parser based on the
 //! generic dialect is also tested (on the inputs it can handle).
 
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, PostgreSqlDialect};
 use sqlparser::parser::ParserError;
-use sqlparser::test_utils::*;
 
 #[test]
 fn parse_create_table_with_defaults() {

--- a/tests/sqlparser_regression.rs
+++ b/tests/sqlparser_regression.rs
@@ -10,6 +10,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![warn(clippy::all)]
+
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -10,11 +10,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-#[path = "macros/mod.rs"]
-mod macros;
+#![warn(clippy::all)]
+//! Test SQL syntax specific to Snowflake. The parser based on the
+//! generic dialect is also tested (on the inputs it can handle).
 
-use sqlparser::test_utils::*;
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, SnowflakeDialect};
 use sqlparser::tokenizer::*;

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -14,9 +14,12 @@
 //! Test SQL syntax specific to SQLite. The parser based on the
 //! generic dialect is also tested (on the inputs it can handle).
 
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, SQLiteDialect};
-use sqlparser::test_utils::*;
 use sqlparser::tokenizer::Token;
 
 #[test]

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -10,6 +10,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Re-export everything from `src/test_utils.rs`.
+pub use sqlparser::test_utils::*;
+
+// For the test-only macros we take a different approach of keeping them here
+// rather than in the library crate.
+//
+// This is because we don't need any of them to be shared between the
+// integration tests (i.e. `tests/*`) and the unit tests (i.e. `src/*`),
+// but also because Rust doesn't scope macros to a particular module
+// (and while we export internal helpers as sqlparser::test_utils::<...>,
+// expecting our users to abstain from relying on them, exporting internal
+// macros at the top level, like `sqlparser::nest` was deemed too confusing).
+
+#[macro_export]
 macro_rules! nest {
     ($base:expr $(, $join:expr)*) => {
         TableFactor::NestedJoin(Box::new(TableWithJoins {


### PR DESCRIPTION
Initially discussed in https://github.com/ballista-compute/sqlparser-rs/issues/223 and  https://github.com/ballista-compute/sqlparser-rs/pull/244. Closes #223.

The description copied from the commit:

Snowflake diverges from the standard and from most of the other implementations by allowing extra parentheses not only around a join, but around lone table names (e.g. `FROM (mytable [AS alias])`) and around derived tables (e.g. `FROM ((SELECT ...)  [AS alias])`) as well.

Initially this was implemented in https://github.com/ballista-compute/sqlparser-rs/issues/154 by (ab)using `TableFactor::NestedJoin` to represent anything nested in extra set of parens.

Afterwards we learned in https://github.com/ballista-compute/sqlparser-rs/issues/223 that in cases of such extraneous nesting Snowflake allows specifying the alias both inside and outside parens, but not both - consider:

    FROM (table_factor AS inner_alias) AS outer_alias

We've considered implementing this by changing `TableFactor::NestedJoin` to a `TableFactor::Nested { inner: TableWithJoins, alias: Option<TableAlias> }`, but that seemed too generic, as no known dialect supports duplicate aliases, as shown above, nor naming nested joins `(foo NATURAL JOIN bar) alias`. So we decided on making a smaller change (with no modifications to the AST), that is also more appropriate to the contributors to the Snowflake dialect:

1) Revert #154 by rejecting `FROM (table or derived table)` in most dialects.

2) For `dialect_of!(self is SnowflakeDialect | GenericDialect)` parse
and strip the extraneous parentheses:

   `(mytable) AS alias` -> `(mytable AS alias)`