### PR TITLE
Support ANALYZE TABLE syntax

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -431,15 +431,6 @@ impl fmt::Display for WindowFrameBound {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Statement {
-    // EXPLAIN
-    Explain {
-        // Carry out the command and show actual run times and other statistics.
-        analyze: bool,
-        // Display additional information regarding the plan.
-        verbose: bool,
-        /// A SQL query that specifies what to explain
-        statement: Box<Statement>,
-    },
     /// SELECT
     Query(Box<Query>),
     /// INSERT
@@ -592,6 +583,20 @@ pub enum Statement {
         data_types: Vec<DataType>,
         statement: Box<Statement>,
     },
+    /// EXPLAIN
+    Explain {
+        /// Carry out the command and show actual run times and other statistics.
+        analyze: bool,
+        // Display additional information regarding the plan.
+        verbose: bool,
+        /// A SQL query that specifies what to explain
+        statement: Box<Statement>,
+    },
+    /// ANALYZE
+    Analyze {
+        /// Name of table
+        table_name: ObjectName,
+    },
 }
 
 impl fmt::Display for Statement {
@@ -617,6 +622,7 @@ impl fmt::Display for Statement {
 
                 write!(f, "{}", statement)
             }
+            Statement::Analyze { table_name } => write!(f, "ANALYZE TABLE {}", table_name),
             Statement::Query(s) => write!(f, "{}", s),
             Statement::Insert {
                 table_name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1807,16 +1807,11 @@ impl<'a> Parser<'a> {
 
     pub fn parse_analyze(&mut self) -> Result<Statement, ParserError> {
         // ANALYZE TABLE table_name
-        let t = self.expect_keyword(Keyword::TABLE)?;
+        self.expect_keyword(Keyword::TABLE)?;
 
         let table_name = self.parse_object_name()?;
-        println!("{:?}", t);
 
-        println!("{:?}", table_name);
-
-        Ok(Statement::Analyze {
-            table_name,
-        })
+        Ok(Statement::Analyze { table_name })
     }
 
     /// Parse a query expression, i.e. a `SELECT` statement optionally

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -132,6 +132,7 @@ impl<'a> Parser<'a> {
         match self.next_token() {
             Token::Word(w) => match w.keyword {
                 Keyword::EXPLAIN => Ok(self.parse_explain()?),
+                Keyword::ANALYZE => Ok(self.parse_analyze()?),
                 Keyword::SELECT | Keyword::WITH | Keyword::VALUES => {
                     self.prev_token();
                     Ok(Statement::Query(Box::new(self.parse_query()?)))
@@ -1801,6 +1802,20 @@ impl<'a> Parser<'a> {
             analyze,
             verbose,
             statement,
+        })
+    }
+
+    pub fn parse_analyze(&mut self) -> Result<Statement, ParserError> {
+        // ANALYZE TABLE table_name
+        let t = self.expect_keyword(Keyword::TABLE)?;
+
+        let table_name = self.parse_object_name()?;
+        println!("{:?}", t);
+
+        println!("{:?}", table_name);
+
+        Ok(Statement::Analyze {
+            table_name,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1640,6 +1640,18 @@ fn parse_explain_analyze_with_simple_select() {
 }
 
 #[test]
+fn parse_simple_analyze() {
+    let sql = "ANALYZE TABLE t";
+    let stmt = verified_stmt(sql);
+    assert_eq!(
+        stmt,
+        Statement::Analyze {
+            table_name: ObjectName(vec![Ident::new("t")])
+        }
+    );
+}
+
+#[test]
 fn parse_named_argument_function() {
     let sql = "SELECT FUN(a => '1', b => '2') FROM foo";
     let select = verified_only_select(sql);


### PR DESCRIPTION
Also FYI @andygrove I want to add this for DataFusion.

There are quite some different syntax versions for this, so for now I think it is best to stick to `ANALYZE TABLE [table_name]` and support further syntax later on. 

https://www.postgresql.org/docs/9.0/sql-analyze.html
https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-aux-analyze-table.html
https://dev.mysql.com/doc/refman/5.6/en/analyze-table.html



