### PR TITLE
Parse floats without leading number

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -403,17 +403,17 @@ impl<'a> Tokenizer<'a> {
                     }
                     s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
 
+                    if s == "." {
+                        return Ok(Some(Token::Period));
+                    }
+
                     let long = if chars.peek() == Some(&'L') {
                         chars.next();
                         true
                     } else {
                         false
                     };
-                    if s == "." {
-                        Ok(Some(Token::Period))
-                    } else {
-                        Ok(Some(Token::Number(s, long)))
-                    }
+                    Ok(Some(Token::Number(s, long)))
                 }
                 // punctuation
                 '(' => self.consume_and_return(chars, Token::LParen),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -394,15 +394,17 @@ impl<'a> Tokenizer<'a> {
                         )
                     }
                 }
-                // numbers
+                // numbers and period
                 '0'..='9' | '.' => {
                     let mut s = peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
+                    // match one period
                     if let Some('.') = chars.peek() {
                         s.push('.');
                         chars.next();
                     }
                     s += &peeking_take_while(chars, |ch| matches!(ch, '0'..='9'));
 
+                    // No number -> Token::Period
                     if s == "." {
                         return Ok(Some(Token::Period));
                     }

--- a/tests/sqlparser_regression.rs
+++ b/tests/sqlparser_regression.rs
@@ -27,8 +27,8 @@ macro_rules! tpch_tests {
             let dialect = GenericDialect {};
 
             let res = Parser::parse_sql(&dialect, QUERIES[$value -1]);
-            // Ignore 6.sql and 22.sql
-            if $value != 6 && $value != 22 {
+            // Ignore 22.sql
+            if $value != 22 {
                 assert!(res.is_ok());
             }
         }


### PR DESCRIPTION
This fixes parsing TCPH query 6 (`.01`)

@andygrove