### PR TITLE
Implement TRY_CAST

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -201,6 +201,12 @@ pub enum Expr {
         expr: Box<Expr>,
         data_type: DataType,
     },
+    /// TRY_CAST an expression to a different data type e.g. `TRY_CAST(foo AS VARCHAR(123))`
+    //  this differs from CAST in the choice of how to implement invalid conversions
+    TryCast {
+        expr: Box<Expr>,
+        data_type: DataType,
+    },
     /// EXTRACT(DateTimeField FROM <expr>)
     Extract {
         field: DateTimeField,
@@ -309,6 +315,7 @@ impl fmt::Display for Expr {
                 }
             }
             Expr::Cast { expr, data_type } => write!(f, "CAST({} AS {})", expr, data_type),
+            Expr::TryCast { expr, data_type } => write!(f, "TRY_CAST({} AS {})", expr, data_type),
             Expr::Extract { field, expr } => write!(f, "EXTRACT({} FROM {})", field, expr),
             Expr::Collate { expr, collation } => write!(f, "{} COLLATE {}", expr, collation),
             Expr::Nested(ast) => write!(f, "({})", ast),

--- a/src/dialect/keywords.rs
+++ b/src/dialect/keywords.rs
@@ -456,6 +456,7 @@ define_keywords!(
     TRIM_ARRAY,
     TRUE,
     TRUNCATE,
+    TRY_CAST,
     UESCAPE,
     UNBOUNDED,
     UNCOMMITTED,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -352,6 +352,7 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::CASE => self.parse_case_expr(),
                 Keyword::CAST => self.parse_cast_expr(),
+                Keyword::TRY_CAST => self.parse_try_cast_expr(),
                 Keyword::EXISTS => self.parse_exists_expr(),
                 Keyword::EXTRACT => self.parse_extract_expr(),
                 Keyword::SUBSTRING => self.parse_substring_expr(),
@@ -586,6 +587,19 @@ impl<'a> Parser<'a> {
         let data_type = self.parse_data_type()?;
         self.expect_token(&Token::RParen)?;
         Ok(Expr::Cast {
+            expr: Box::new(expr),
+            data_type,
+        })
+    }
+
+    /// Parse a SQL TRY_CAST function e.g. `TRY_CAST(expr AS FLOAT)`
+    pub fn parse_try_cast_expr(&mut self) -> Result<Expr, ParserError> {
+        self.expect_token(&Token::LParen)?;
+        let expr = self.parse_expr()?;
+        self.expect_keyword(Keyword::AS)?;
+        let data_type = self.parse_data_type()?;
+        self.expect_token(&Token::RParen)?;
+        Ok(Expr::TryCast {
             expr: Box::new(expr),
             data_type,
         })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1820,7 +1820,7 @@ impl<'a> Parser<'a> {
         let columns = self.parse_parenthesized_column_list(Optional)?;
         self.expect_keywords(&[Keyword::FROM, Keyword::STDIN])?;
         self.expect_token(&Token::SemiColon)?;
-        let values = self.parse_tsv()?;
+        let values = self.parse_tsv();
         Ok(Statement::Copy {
             table_name,
             columns,
@@ -1830,9 +1830,8 @@ impl<'a> Parser<'a> {
 
     /// Parse a tab separated values in
     /// COPY payload
-    fn parse_tsv(&mut self) -> Result<Vec<Option<String>>, ParserError> {
-        let values = self.parse_tab_value();
-        Ok(values)
+    fn parse_tsv(&mut self) -> Vec<Option<String>> {
+        self.parse_tab_value()
     }
 
     fn parse_tab_value(&mut self) -> Vec<Option<String>> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1831,11 +1831,11 @@ impl<'a> Parser<'a> {
     /// Parse a tab separated values in
     /// COPY payload
     fn parse_tsv(&mut self) -> Result<Vec<Option<String>>, ParserError> {
-        let values = self.parse_tab_value()?;
+        let values = self.parse_tab_value();
         Ok(values)
     }
 
-    fn parse_tab_value(&mut self) -> Result<Vec<Option<String>>, ParserError> {
+    fn parse_tab_value(&mut self) -> Vec<Option<String>> {
         let mut values = vec![];
         let mut content = String::from("");
         while let Some(t) = self.next_token_no_skip() {
@@ -1850,7 +1850,7 @@ impl<'a> Parser<'a> {
                 }
                 Token::Backslash => {
                     if self.consume_token(&Token::Period) {
-                        return Ok(values);
+                        return values;
                     }
                     if let Token::Word(w) = self.next_token() {
                         if w.value == "N" {
@@ -1863,7 +1863,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        Ok(values)
+        values
     }
 
     /// Parse a literal value (numbers, strings, date/time, booleans)

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -626,6 +626,7 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn consume_and_return(
         &self,
         chars: &mut Peekable<Chars<'_>>,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1253,6 +1253,7 @@ fn parse_assert() {
 }
 
 #[test]
+#[allow(clippy::collapsible_match)]
 fn parse_assert_message() {
     let sql = "ASSERT (SELECT COUNT(*) FROM my_table) > 0 AS 'No rows in my_table'";
     let ast = one_statement_parses_to(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -982,6 +982,35 @@ fn parse_cast() {
 }
 
 #[test]
+fn parse_try_cast() {
+    let sql = "SELECT TRY_CAST(id AS BIGINT) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::TryCast {
+            expr: Box::new(Expr::Identifier(Ident::new("id"))),
+            data_type: DataType::BigInt
+        },
+        expr_from_projection(only(&select.projection))
+    );
+    one_statement_parses_to(
+        "SELECT TRY_CAST(id AS BIGINT) FROM customer",
+        "SELECT TRY_CAST(id AS BIGINT) FROM customer",
+    );
+
+    verified_stmt("SELECT TRY_CAST(id AS NUMERIC) FROM customer");
+
+    one_statement_parses_to(
+        "SELECT TRY_CAST(id AS DEC) FROM customer",
+        "SELECT TRY_CAST(id AS NUMERIC) FROM customer",
+    );
+
+    one_statement_parses_to(
+        "SELECT TRY_CAST(id AS DECIMAL) FROM customer",
+        "SELECT TRY_CAST(id AS NUMERIC) FROM customer",
+    );
+}
+
+#[test]
 fn parse_extract() {
     let sql = "SELECT EXTRACT(YEAR FROM d)";
     let select = verified_only_select(sql);


### PR DESCRIPTION
Hi @andygrove 

This change adds the TRY_CAST alongside CAST so that the choice on how to handle data casting errors can be differentiated.

See: https://docs.microsoft.com/en-us/sql/t-sql/functions/try-cast-transact-sql?view=sql-server-ver15

Also fixed a clippy error that must have been added recently.