### PR TITLE
[parser] Return error instead of panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! println!("AST: {:?}", ast);
 //! ```
-#![warn(clippy::all)]
+#![allow(clippy::upper_case_acronyms)]
 
 pub mod ast;
 #[macro_use]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2199,14 +2199,7 @@ impl<'a> Parser<'a> {
                 None
             };
 
-            Ok(Query {
-                with,
-                body,
-                limit,
-                order_by,
-                offset,
-                fetch,
-            })
+            Ok(Query { with, body, order_by, limit, offset, fetch })
         } else {
             let insert = self.parse_insert()?;
             Ok(Query {
@@ -2409,19 +2402,7 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Select {
-            distinct,
-            top,
-            projection,
-            from,
-            selection,
-            lateral_views,
-            group_by,
-            cluster_by,
-            distribute_by,
-            sort_by,
-            having,
-        })
+        Ok(Select { distinct, top, projection, from, lateral_views, selection, group_by, cluster_by, distribute_by, sort_by, having })
     }
 
     pub fn parse_set(&mut self) -> Result<Statement, ParserError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -883,7 +883,7 @@ impl<'a> Parser<'a> {
                     }
                 }
                 // Can only happen if `get_next_precedence` got out of sync with this function
-                _ => panic!("No infix parser for token {:?}", tok),
+                _ => parser_err!(format!("No infix parser for token {:?}", tok)),
             }
         } else if Token::DoubleColon == tok {
             self.parse_pg_cast(expr)
@@ -897,7 +897,7 @@ impl<'a> Parser<'a> {
             self.parse_map_access(expr)
         } else {
             // Can only happen if `get_next_precedence` got out of sync with this function
-            panic!("No infix parser for token {:?}", tok)
+            parser_err!(format!("No infix parser for token {:?}", tok))
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2199,7 +2199,14 @@ impl<'a> Parser<'a> {
                 None
             };
 
-            Ok(Query { with, body, order_by, limit, offset, fetch })
+            Ok(Query {
+                with,
+                body,
+                order_by,
+                limit,
+                offset,
+                fetch,
+            })
         } else {
             let insert = self.parse_insert()?;
             Ok(Query {
@@ -2402,7 +2409,19 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Select { distinct, top, projection, from, lateral_views, selection, group_by, cluster_by, distribute_by, sort_by, having })
+        Ok(Select {
+            distinct,
+            top,
+            projection,
+            from,
+            lateral_views,
+            selection,
+            group_by,
+            cluster_by,
+            distribute_by,
+            sort_by,
+            having,
+        })
     }
 
     pub fn parse_set(&mut self) -> Result<Statement, ParserError> {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -24,7 +24,7 @@ use test_utils::{all_dialects, expr_from_projection, join, number, only, table, 
 
 use matches::assert_matches;
 use sqlparser::ast::*;
-use sqlparser::dialect::{keywords::ALL_KEYWORDS, SQLiteDialect};
+use sqlparser::dialect::{keywords::ALL_KEYWORDS, GenericDialect, SQLiteDialect};
 use sqlparser::parser::{Parser, ParserError};
 
 #[test]
@@ -109,7 +109,7 @@ fn parse_insert_sqlite() {
     .unwrap()
     {
         Statement::Insert { or, .. } => assert_eq!(or, expected_action),
-        _ => panic!(sql.to_string()),
+        _ => panic!("{}", sql.to_string()),
     };
 
     let sql = "INSERT INTO test_table(id) VALUES(1)";
@@ -354,6 +354,15 @@ fn test_eof_after_as() {
     let res = parse_sql_statements("SELECT 1 FROM foo AS");
     assert_eq!(
         ParserError::ParserError("Expected an identifier after AS, found: EOF".to_string()),
+        res.unwrap_err()
+    );
+}
+
+#[test]
+fn test_no_infix_error() {
+    let res = Parser::parse_sql(&GenericDialect {}, "ASSERT-URA<<");
+    assert_eq!(
+        ParserError::ParserError("No infix parser for token ShiftLeft".to_string()),
         res.unwrap_err()
     );
 }


### PR DESCRIPTION
## Summary
Under fuzz, always panic at `parse_infix` due to the query like: `ASSERT-URA<<`.
This patch change the panic to error, after this patch, the fuzz looks good for 5 minutes(Without this patch, it would be panic soon):
```
------------------------[  0 days 00 hrs 05 mins 31 secs ]----------------------
  Iterations : 2,923,487 [2.92M]
  Mode [3/3] : Feedback Driven Mode
      Target : hfuzz_target/x86_64-unknown-linux-gnu/release/fuzz_parse_sql
     Threads : 8, CPUs: 16, CPU%: 855% [53%/CPU]
       Speed : 8,956/sec [avg: 8,832]
     Crashes : 0 [unique: 0, blocklist: 0, verified: 0]
    Timeouts : 0 [1 sec]
 Corpus Size : 6,255, max: 8,192 bytes, init: 9,733 files
  Cov Update : 0 days 00 hrs 00 mins 02 secs ago
    Coverage : edge: 4,130/800,478 [0%] pc: 24 cmp: 225,076
```

Closes #314 